### PR TITLE
Fix module version number to create 1.1.0 release

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -3,7 +3,7 @@
     "title": "Foundry Redirect: Better invitation links",
     "description": "A module to create static invitation links which look like a regular URL, and don't need to be resent every time your IP address changes",
     "author": "JarrettSpiker",
-    "version": "1.0.5",
+    "version": "1.1.0",
     "minimumCoreVersion": "0.7.9",
     "compatibleCoreVersion" : "9",
     "scripts": [


### PR DESCRIPTION
Should actually result in the creation of the 1.1.0 release, which is what #5  was supposed to do