### PR TITLE
Simplify acquisition of form element

### DIFF
--- a/src/scripts/module.ts
+++ b/src/scripts/module.ts
@@ -62,10 +62,7 @@ Hooks.on("renderInvitationLinks", (links:InvitationLinks, html:JQuery) => {
         // If the window was reloaded, the JQuery is the Form
         let formHtml : HTMLFormElement | undefined;
         if(windowContent.classList.contains("window-app") && windowContent instanceof HTMLDivElement){
-            let potentialForm = windowContent.lastElementChild?.lastElementChild;
-            if(potentialForm instanceof HTMLFormElement){
-                formHtml = potentialForm;
-            }
+            formHtml = windowContent.querySelector("form");
         } else if(windowContent instanceof HTMLFormElement){
             formHtml = windowContent;
         }


### PR DESCRIPTION
When rendering the app for the first time, a brittle manual tree walk is used. Instead, query for the form element directly (as we expect there to only be one). This ensures that other minor modifications to the app don't break form acquisition.

---

Specifically, a module which patches applications to be resizable by default will result in the "resize handle" element being added to the app, which then confuses the current last-element-based lookup.

(Example libwrapper code which shows this effect:)

```js
libWrapper.register(
  "foundry-redirect",
  "Application.defaultOptions",
  (wrapped, ...args) => ({...wrapped(...args), resizable: true}),
  "WRAPPER",
)
```